### PR TITLE
Correct coordinate units

### DIFF
--- a/data/ds_byu.py
+++ b/data/ds_byu.py
@@ -176,11 +176,12 @@ class BYUMotorDataset(Dataset):
         patches_i, patches_l = [], []
 
         if row["Number of motors"] > 0:
-            spc = row["Voxel spacing"]
+            # train_labels.csv 에 기록된 모터 좌표는 이미 voxel 단위이므로
+            # 별도의 spacing 보정 없이 그대로 사용한다.
             ctr = (
-                int(row["Motor axis 0"] / spc),
-                int(row["Motor axis 1"] / spc),
-                int(row["Motor axis 2"] / spc),
+                int(row["Motor axis 0"]),
+                int(row["Motor axis 1"]),
+                int(row["Motor axis 2"]),
             )
             for _ in range(POS_PER_TOMO):
                 im, lb = self._pos_patch(vol, ctr)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -267,10 +267,11 @@ def main():
             pred_has = (df_pred.iloc[0, 1:4] >= 0).all()
             gt_has   = row["Number of motors"] > 0
             if gt_has and pred_has:
+                # predicted 좌표는 Angstrom 단위이므로 voxel 단위로 맞춰 비교
                 dist = np.linalg.norm(
-                    df_pred.iloc[0, 1:4].values -
+                    df_pred.iloc[0, 1:4].values / spacing -
                     row[["Motor axis 0","Motor axis 1","Motor axis 2"]].values
-                ) / spacing
+                )
                 if dist <= TH_VOX:
                     tp += 1
                 else:


### PR DESCRIPTION
## Summary
- fix BYUMotorDataset positive patch center not to divide by spacing
- clarify unit conversion when computing validation distance

## Testing
- `pytest -q` *(실패: command not found)*