### PR TITLE
Add peak dilution debug script

### DIFF
--- a/tests/check_peak_dilution.py
+++ b/tests/check_peak_dilution.py
@@ -1,0 +1,28 @@
+"""tests/check_peak_dilution.py
+Synthetic grid_reconstruct_3d test to confirm peak dilution.
+"""
+import torch
+from torch.nn.functional import sigmoid
+from utils import grid_reconstruct_3d
+
+# 작은 패치 2x2x2 를 2x2x2 격자로 배치
+roi = (2, 2, 2)
+num_patches = 8  # 2x2x2 grid
+patches = torch.zeros((num_patches, 1, *roi))
+
+# 첫 번째 패치 한 곳만 강한 신호(1.0)
+patches[0, 0, 0, 0, 0] = 1.0
+
+# 각 패치의 위치 (비중복)
+locs = []
+for z in range(0, 4, 2):
+    for y in range(0, 4, 2):
+        for x in range(0, 4, 2):
+            locs.append((z, y, x))
+locs = torch.tensor(locs)
+
+vol_shape = (4, 4, 4)
+recon = grid_reconstruct_3d(patches, locs, vol_shape)
+
+print("max value before sigmoid :", recon.max().item())
+print("max value after sigmoid  :", sigmoid(recon).max().item())


### PR DESCRIPTION
## Summary
- add a small script under tests/ to inspect grid_reconstruct_3d output

## Testing
- `python tests/check_peak_dilution.py` *(fails: No module named 'torch')*
- `python tests/test_metric_f2.py` *(fails: No module named 'pandas')*