### PR TITLE
Add checkpoint saving and logit comparison

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -103,6 +103,8 @@ def parse_args():
                     help="Use partial validation: 10 pos + 10 neg tomograms")
     ap.add_argument("--val-freq", type=int, default=1,
                     help="Run validation every N epochs (≥1).")
+    ap.add_argument("--save-ckpt", type=str, default=None,
+                    help="Checkpoint prefix; if set, '{prefix}_epN.pt' files are saved")
     return ap.parse_args()
 
 # ============================================================================
@@ -225,6 +227,12 @@ def main():
                 "loss/train": ep_loss / len(tr_dl),
                 "lr": sch.get_last_lr()[0]
             }, step=ep)
+        if args.save_ckpt:
+            ckpt_base = pathlib.Path(args.save_ckpt)
+            ckpt_base.parent.mkdir(parents=True, exist_ok=True)
+            ckpt_fn = ckpt_base.with_name(f"{ckpt_base.stem}_ep{ep+1}.pt")
+            torch.save({"epoch": ep + 1, "model": net.state_dict()}, ckpt_fn)
+            print(f"[INFO] saved checkpoint to {ckpt_fn}")
         torch.cuda.empty_cache(); gc.collect()
 
         # ----------------- Validation (conditional) ------------------

--- a/tests/check_patch_logits.py
+++ b/tests/check_patch_logits.py
@@ -1,7 +1,9 @@
 """tests/check_patch_logits.py
-BYUMotorDataset에서 양성 패치만 골라 BYUNet 추론 logits.max()를 출력한다.
+BYUMotorDataset에서 양성 패치를 골라 무작위 가중치와 학습된 가중치의
+logits.max() 값을 비교한다.
 """
 
+import argparse
 import torch
 import pandas as pd
 
@@ -11,7 +13,14 @@ from models.net_byu import BYUNet
 # ── device 설정 ───────────────────────────────────────────────
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 
-# ── 1. 양성 tomogram 선택 ─────────────────────────────────────
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ckpt", required=True, help="불러올 .pt 파일 경로")
+    return ap.parse_args()
+
+# ── 1. 인자 파싱 및 양성 tomogram 선택 ────────────────────────
+args = parse_args()
 labels_df = pd.read_csv(LABEL_CSV)
 pos_rows  = labels_df.query("`Number of motors` >= 1")
 if pos_rows.empty:
@@ -25,17 +34,30 @@ ds = BYUMotorDataset([TID], mode="train", split="train")
 item = ds[0]  # 첫 번째 샘플 (양성 패치 포함)
 imgs, lbls = item["image"], item["label"]
 
-# ── 3. 모델 로드 (랜덤 가중치) ───────────────────────────────
+# ── 3. 모델 로드 ─────────────────────────────────────────────
+net_rand = BYUNet({"backbone": "resnet34"}).to(DEVICE)
+net_rand.eval()
+
 net = BYUNet({"backbone": "resnet34"}).to(DEVICE)
+state = torch.load(args.ckpt, map_location=DEVICE)
+if "model" in state:
+    state = state["model"]
+net.load_state_dict(state, strict=False)
 net.eval()
 
-# ── 4. 양성 패치만 추론하여 logits.max() 확인 ────────────────
+# ── 4. 양성 패치만 추론하여 logits 비교 ────────────────────
 for idx, (im, lb) in enumerate(zip(imgs, lbls)):
     if lb.max() == 0:
         continue  # 음성 패치 건너뜀
 
     with torch.no_grad():
         batch = {"image": im.unsqueeze(0).to(DEVICE)}
-        out   = net(batch)
-    mx = out["logits"].max().item()
-    print(f"patch {idx} logits.max() = {mx:.4f}")
+        rand_out = net_rand(batch)
+        ckpt_out = net(batch)
+
+    rand_mx = rand_out["logits"].max().item()
+    ckpt_mx = ckpt_out["logits"].max().item()
+    diff    = ckpt_mx - rand_mx
+    print(
+        f"patch {idx} random={rand_mx:.4f}, ckpt={ckpt_mx:.4f}, Δ={diff:.4f}"
+    )


### PR DESCRIPTION
## Summary
- add `--save-ckpt` option to `train.py` to save state dict each epoch
- enhance `check_patch_logits.py` to compare random vs trained checkpoints

## Testing
- `python tests/smoke_forward.py` *(fails: ModuleNotFoundError: No module named 'torch')*