### PR TITLE
Add distance-aware top-k postprocess

### DIFF
--- a/postprocess/pp_byu.py
+++ b/postprocess/pp_byu.py
@@ -14,8 +14,10 @@ import torch, pandas as pd, numpy as np
 
 # ───── 하이퍼 파라미터 ───────────────────────────────
 VOX_SPACING_A = 10.0          # voxel ↔ Å 변환 값
-NMS_RADIUS_VX = 15             # max-pool radius (voxel)
+NMS_RADIUS_VX = 15            # max-pool radius (voxel)
 THRESH        = 0.50          # 최고 확률 cutoff
+TOPK          = 5             # 후보 peak 개수
+DIST_WEIGHT   = 1e-3          # joint score 거리 패널티 가중치
 CUDA_OK       = torch.cuda.is_available()
 
 # ───── 3-D NMS (FP16 지원) ───────────────────────────
@@ -37,10 +39,22 @@ def post_process_volume(
     prob_vol: Union[torch.Tensor, np.ndarray],
     *,
     spacing: float = VOX_SPACING_A,
-    tomo_id: str   = "unknown"
+    tomo_id: str   = "unknown",
+    topk: int = TOPK,
+    gt_coord: Tuple[float, float, float] | None = None,
+    dist_weight: float = DIST_WEIGHT,
 ) -> pd.DataFrame:
     """
     확률 볼륨 → 1 row DataFrame (없으면 -1,-1,-1)
+
+    Parameters
+    ----------
+    prob_vol : softmax 확률 볼륨 또는 로짓 텐서
+    spacing  : voxel ↔ Å 변환 값
+    tomo_id  : 결과 DataFrame 에 기록될 tomogram ID
+    topk     : NMS 후 고려할 최고 확률 peak 수
+    gt_coord : GT 좌표가 주어지면 거리 페널티를 적용해 최종 좌표 결정
+    dist_weight : joint score 계산 시 거리 가중치
     """
     # 0) tensor 로 변환 및 Device / dtype 설정 --------------------
     if isinstance(prob_vol, np.ndarray):
@@ -55,9 +69,31 @@ def post_process_volume(
         prob = prob.float()                         # CPU fp32
 
     # 1) NMS & peak 찾기 -----------------------------------------
-    peaks      = simple_nms(prob)                   # 같은 device/dtype
-    conf, idx  = peaks.view(-1).max(0)              # GPU argmax 가능
-    conf_val   = conf.float().item()                # Python float
+    peaks = simple_nms(prob)                        # 같은 device/dtype
+    flat = peaks.view(-1).float()
+    k = min(topk, flat.numel())
+    conf_k, idx_k = flat.topk(k)
+
+    # 2) 후보 좌표 계산 -----------------------------------------
+    D, H, W = prob.shape
+    best = {"score": -float("inf"), "conf": 0.0, "coord": [-1.0, -1.0, -1.0]}
+    for conf, idx in zip(conf_k, idx_k):
+        conf_v = float(conf.item())
+        ii = int(idx.item())
+        z = ii // (H * W)
+        y = (ii // W) % H
+        x = ii % W
+        coord_A = np.array([z * spacing, y * spacing, x * spacing], dtype=float)
+
+        dist = 0.0
+        if gt_coord is not None:
+            dist = float(np.linalg.norm(coord_A - np.asarray(gt_coord)))
+        score = conf_v - dist_weight * dist
+
+        if score > best["score"]:
+            best = {"score": score, "conf": conf_v, "coord": coord_A.tolist()}
+
+    conf_val = best["conf"]
 
     # 2) 모터 없음 -----------------------------------------------
     if conf_val < THRESH:
@@ -68,12 +104,7 @@ def post_process_volume(
         )
 
     # 3) voxel → Å 좌표 변환 -------------------------------------
-    D, H, W = prob.shape
-    idx     = idx.item()
-    z = idx // (H * W)
-    y = (idx // W) % H
-    x = idx % W
-    coord_Å = [z * spacing, y * spacing, x * spacing]
+    coord_Å = best["coord"]
 
     return pd.DataFrame(
         [[tomo_id, *coord_Å, conf_val]],

--- a/tests/run_postprocess_check.py
+++ b/tests/run_postprocess_check.py
@@ -23,5 +23,5 @@ motor_logit = torch.tensor(full_vol) * 6.0        # 강도 조절
 bg_logit    = torch.zeros_like(motor_logit)
 logits = torch.stack([bg_logit, motor_logit])     # (2,D,H,W)
 
-df = post_process_volume(logits, spacing, tomo_id=tid)
+df = post_process_volume(logits, spacing, tomo_id=tid, topk=5)
 print(df)


### PR DESCRIPTION
## Summary
- allow selecting top-k peaks in BYU postprocess
- add distance penalty and joint scoring option
- update run_postprocess_check example

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*