### PR TITLE
패치 생성 및 후처리 설정 조정

### DIFF
--- a/configs/cfg_resnet34.py
+++ b/configs/cfg_resnet34.py
@@ -28,7 +28,7 @@ cfg = get_cfg(
 
     # 손실/metric
     beta          = 2,
-    pos_weight    = 24.0,         # [motor, background]  (예시)
+    pos_weight    = 2.0,          # [motor, background]
 
     # 로그
     disable_wandb = False,           # wandb 사용

--- a/data/ds_byu.py
+++ b/data/ds_byu.py
@@ -23,7 +23,7 @@ from utils import grid_split_3d, gaussian_kernel_3d
 
 # ─── global hyper‑params ──────────────────────────────────────────
 ROI: Tuple[int, int, int] = (96, 96, 96)          # (d, h, w)
-POS_PER_TOMO, NEG_PER_TOMO = 3, 1                 # batch 내부 3:1 → DataLoader 측 6:2 보장
+POS_PER_TOMO, NEG_PER_TOMO = 2, 2                 # 양성/음성 패치 2개씩 (3:3 Sampler용)
 SIGMA_PX   = 8                                  # spacing‑aware σ 는 ROI 프로토타입 확인 후 조정
 CUTOFF     = 0.02
 MAX_TRY_NEG = 50

--- a/postprocess/pp_byu.py
+++ b/postprocess/pp_byu.py
@@ -17,7 +17,7 @@ VOX_SPACING_A = 10.0          # voxel ↔ Å 변환 값
 NMS_RADIUS_VX = 15            # max-pool radius (voxel)
 THRESH        = 0.30          # 최고 확률 cutoff
 TOPK          = 5             # 후보 peak 개수
-DIST_WEIGHT   = 1e-3          # joint score 거리 패널티 가중치 (1/1000 Å)
+DIST_WEIGHT   = 0.02          # joint score 거리 패널티 가중치
 CUDA_OK       = torch.cuda.is_available()
 
 # ───── 3-D NMS (FP16 지원) ───────────────────────────
@@ -42,7 +42,7 @@ def post_process_volume(
     tomo_id: str   = "unknown",
     topk: int = TOPK,
     gt_coord: Tuple[float, float, float] | None = None,
-    dist_weight: float | None = None,
+    dist_weight: float | None = DIST_WEIGHT,
     expected_max_dist: float = 1000.0,
     n_keep: int = 1,
     score_mode: str = "linear",
@@ -57,7 +57,7 @@ def post_process_volume(
     tomo_id  : 결과 DataFrame 에 기록될 tomogram ID
     topk     : NMS 후 고려할 최고 확률 peak 수
     gt_coord : GT 좌표가 주어지면 거리 페널티를 적용해 최종 좌표 결정
-    dist_weight : joint score 계산 시 거리 가중치 (기본: 1/expected_max_dist)
+    dist_weight : joint score 계산 시 거리 가중치 (기본: DIST_WEIGHT)
     expected_max_dist : GT 와 예측 좌표 사이 최대 예상 거리 [Å]
     n_keep : 점수순으로 반환할 후보 개수
     score_mode : 점수 계산 방식 ("linear" 또는 "exp")

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -4,7 +4,7 @@ BYU Motor – Training Script  (val-freq 지원 버전)
 
 Features:
 - Dataset ROI = 96³
-- BalancedSampler for 6:2 pos:neg tomogram ratio
+- BalancedSampler for 3:3 pos:neg tomogram ratio
 - BYUNet-internal loss (CEPlus) usage
 - Partial validation (--quick-val) with 10 positive + 10 negative samples
 - Spacing-aware post-processing
@@ -42,9 +42,9 @@ PAD_MODE  = "reflect"
 class BalancedSampler(Sampler):
     """
     Finite sampler: 한 에폭에 (kp+kn) * n_batches 만큼만 인덱스 반환
-    kp = 양성, kn = 음성 샘플 수
+    기본 비율은 k_pos=k_neg=3
     """
-    def __init__(self, pos_idx, neg_idx, *, k_pos=6, k_neg=2, seed=42):
+    def __init__(self, pos_idx, neg_idx, *, k_pos=3, k_neg=3, seed=42):
         self.pos, self.neg = list(pos_idx), list(neg_idx)
         self.kp, self.kn   = k_pos, k_neg
         self.rng = random.Random(seed)
@@ -107,7 +107,7 @@ def parse_args():
                     help="Run validation every N epochs (≥1).")
     ap.add_argument("--save-ckpt", type=str, default=None,
                     help="Checkpoint prefix; if set, '{prefix}_epN.pt' files are saved")
-    ap.add_argument("--dist-weight", type=float, default=None,
+    ap.add_argument("--dist-weight", type=float, default=0.02,
                     help="Distance weight for post-processing")
     ap.add_argument("--expected-max-dist", type=float, default=None,
                     help="Override expected max distance in Å")

--- a/tests/overfit_one.py
+++ b/tests/overfit_one.py
@@ -25,7 +25,7 @@ ds = torch.utils.data.Subset(ds_all, [pos_idx])
 dl = torch.utils.data.DataLoader(ds, batch_size=1, collate_fn=simple_collate)
 
 # ── model & optim ---------------------------------------------------
-net = BYUNet({"backbone": "resnet34", "pos_weight": 24.}).to(device)
+net = BYUNet({"backbone": "resnet34", "pos_weight": 2.}).to(device)
 opt = torch.optim.Adam(net.parameters(), lr=1e-3)
 
 # ── training loop ---------------------------------------------------


### PR DESCRIPTION
## Summary
- 양성/음성 패치 수를 2개씩 생성하도록 변경
- BalancedSampler 기본 비율을 3:3으로 수정하고 CLI 기본 `dist-weight` 값 조정
- 후처리 모듈의 거리 가중치 기본값을 0.02로 변경
- pos_weight 값을 2로 낮춰 학습 설정 완화
- 테스트 스크립트의 pos_weight 값 갱신

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*