### PR TITLE
Fix DataLoader batch matching BalancedSampler

### DIFF
--- a/configs/cfg_resnet34.py
+++ b/configs/cfg_resnet34.py
@@ -23,7 +23,7 @@ cfg = get_cfg(
     lr            = 2e-4,
     weight_decay  = 1e-5,
     optimizer     = "AdamW",
-    batch_size    = 8,
+    batch_size    = 6,
     num_workers   = 8,
 
     # 손실/metric

--- a/configs/common_config.py
+++ b/configs/common_config.py
@@ -30,7 +30,7 @@ _DEFAULTS = dict(
     # training
     epochs         = 10,
     lr             = 1e-3,
-    batch_size     = 8,
+    batch_size     = 6,
     num_workers    = 8,
     seed           = 42,
     pin_memory     = True,          # ① GPU 전송 가속

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -4,7 +4,7 @@ BYU Motor – Training Script  (val-freq 지원 버전)
 
 Features:
 - Dataset ROI = 96³
-- BalancedSampler for 3:3 pos:neg tomogram ratio
+- BalancedSampler for 3:3 pos:neg tomogram ratio (batch size = kp+kn)
 - BYUNet-internal loss (CEPlus) usage
 - Partial validation (--quick-val) with 10 positive + 10 negative samples
 - Spacing-aware post-processing
@@ -169,16 +169,18 @@ def main():
     sampler = BalancedSampler(pos_idx, neg_idx)
 
     # Training DataLoader
+    # BalancedSampler 가 (kp+kn) 단위로 인덱스를 반환하므로
+    # DataLoader 의 batch_size 도 동일하게 맞춰 3:3 비율을 유지한다
     tr_dl = DataLoader(
         train_ds,
-        batch_size=cfg.batch_size,
+        batch_size=sampler.kp + sampler.kn,
         sampler=sampler,
         shuffle=False,
         num_workers=cfg.num_workers,
         collate_fn=simple_collate,
         pin_memory=cfg.pin_memory,
         persistent_workers=cfg.persistent_workers,
-        drop_last=True,  # ensure 6+2 per batch
+        drop_last=False,
     )
 
     # Model, optimizer, scheduler, scaler


### PR DESCRIPTION
## Summary
- ensure train loader batches match BalancedSampler's 3:3 ratio
- set batch size to 6 in common and ResNet34 configs
- update comments in training script

## Testing
- `PYTHONPATH=. python tests/test_common_cfg.py` *(fails: No module named 'dotenv')*
- `PYTHONPATH=. python tests/test_score_mode.py` *(fails: No module named 'numpy')*